### PR TITLE
update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/s3-action.yaml
+++ b/.github/workflows/s3-action.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Updates all instances of actions/checkout@v3 to actions/checkout@v4
This is the last file requiring this update, all other files have been updated
Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.